### PR TITLE
Translate site content to Finnish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" href="main.css" media="all" rel="stylesheet">
-    <meta name="description" content="Sampo Lavinen - Simplestack: Tailored Solutions for Software and Data Analytics. Problem solving from Joensuu.">
-    <title>Simplestack - Tailored Solutions by Sampo Lavinen</title>
+    <meta name="description" content="Sampo Lavinen - Simplestack: Räätälöityjä ratkaisuja ohjelmistokehitykseen ja data-analytiikkaan. Ongelmanratkaisua Joensuusta.">
+    <title>Simplestack - Räätälöityjä ratkaisuja - Sampo Lavinen</title>
 </head>
 <body>
     <header>
         <h1>Sampo Lavinen - Simplestack</h1>
-        <p>Tailored Solutions for software development, data analytics, team culture and ways of working</p>
+        <p>Räätälöityjä ratkaisuja ohjelmistokehitykseen, data-analytiikkaan, tiimikulttuuriin ja työskentelytapoihin</p>
         <p align="center">
-            <img alt="Simplestock trading logo" src="./assets/Simplestack.png" width="40%">
+            <img alt="Simplestack-logo" src="./assets/Simplestack.png" width="40%">
         </p>
     </header>
 
     <main>
         <section id="about">
-            <h2>What I Offer</h2>
-            <p>I offer tailored solutions that focus on the specific needs of my clients. Based in Joensuu, Finland, I don't sell pre-made solutions or trendy products; instead, I listen to the problem, analyze it, and deliver a solution that fits. Whether it's software development, data analytics, or building a strong team culture, my goal is always to improve the client's operations with concrete and sustainable results.</p>
-            <p>What matters most to me is that my work truly benefits my clients' business. If nothing is working, you don't need me, and if everything is working, why invest without further improvement? I aim to help my clients continuously develop and ensure that the results speak for themselves.</p>
+            <h2>Mitä tarjoan</h2>
+            <p>Tarjoan räätälöityjä ratkaisuja, jotka keskittyvät asiakkaideni yksilöllisiin tarpeisiin. Joensuussa, Suomessa toimivana en myy valmiita ratkaisuja tai trendikkäitä tuotteita, vaan kuuntelen ongelmaa, analysoin sen ja toimitan siihen sopivan ratkaisun. Olipa kyse ohjelmistokehityksestä, data-analytiikasta tai vahvan tiimikulttuurin rakentamisesta, tavoitteeni on aina parantaa asiakkaan toimintaa konkreettisin ja kestävin tuloksin.</p>
+            <p>Minulle tärkeintä on, että työni hyödyttää aidosti asiakkaideni liiketoimintaa. Jos mikään ei toimi, et tarvitse minua, ja jos kaikki toimii, miksi investoida ilman lisäparannuksia? Pyrin auttamaan asiakkaitani kehittymään jatkuvasti ja varmistamaan, että tulokset puhuvat puolestaan.</p>
         </section>
 
         <section id="contact">
-            <h2>Contact Me</h2>
-            <p>Location: Joensuu, Finland</p>
-            <p>Email: <a href="mailto:sampo@simplestack.eu">sampo@simplestack.eu</a></p>
+            <h2>Ota yhteyttä</h2>
+            <p>Sijainti: Joensuu, Suomi</p>
+            <p>Sähköposti: <a href="mailto:sampo@simplestack.eu">sampo@simplestack.eu</a></p>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- translate all visible text on landing page to Finnish
- update HTML lang attribute to Finnish

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688de93a0824832eaf54496ffd51518f