### PR TITLE
Add canonical link to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" href="main.css" media="all" rel="stylesheet">
+    <link rel="canonical" href="https://www.simplestack.eu/">
     <meta name="description" content="Sampo Lavinen - Simplestack: Räätälöityjä ratkaisuja ohjelmistokehitykseen ja data-engineeringiin. Ongelmanratkaisua Joensuusta.">
     <title>Simplestack - Räätälöityjä ratkaisuja - Sampo Lavinen</title>
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add canonical link to homepage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e43c1658c832e80bc9f9e408afc9b