### PR TITLE
Add social media metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <link type="text/css" href="main.css" media="all" rel="stylesheet">
     <link rel="canonical" href="https://www.simplestack.eu/">
     <meta name="description" content="Sampo Lavinen - Simplestack: Räätälöityjä ratkaisuja ohjelmistokehitykseen ja data-engineeringiin. Ongelmanratkaisua Joensuusta.">
+    <meta property="og:title" content="Simplestack - Räätälöityjä ratkaisuja - Sampo Lavinen">
+    <meta property="og:description" content="Sampo Lavinen – Simplestack: Räätälöityjä ratkaisuja ohjelmistokehitykseen ja data-engineeringiin. Ongelmanratkaisua Joensuusta.">
+    <meta property="og:image" content="https://www.simplestack.eu/assets/Simplestack.png">
+    <meta property="og:url" content="https://www.simplestack.eu/">
+    <meta name="twitter:card" content="summary_large_image">
     <title>Simplestack - Räätälöityjä ratkaisuja - Sampo Lavinen</title>
     <script type="application/ld+json">
     {


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata to the site's head

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e43baa600832eb8217b1476cbe549