### PR TITLE
Use CSS class to center logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <header>
         <h1>Sampo Lavinen - Simplestack</h1>
         <p>Räätälöityjä ratkaisuja ohjelmistokehitykseen, data-engineeringiin, tiimikulttuuriin ja työskentelytapoihin</p>
-        <p align="center">
+        <p class="logo-container">
             <img alt="Simplestack-logo" src="./assets/Simplestack.png" width="40%">
         </p>
     </header>

--- a/main.css
+++ b/main.css
@@ -15,6 +15,9 @@ h1, h2 {
 section p {
     margin: 0 0 0.2em 0;
 }
+.logo-container {
+    text-align: center;
+}
 
 footer {
     margin: 3em 0 0 0;


### PR DESCRIPTION
## Summary
- Replace deprecated align attribute on logo paragraph with a semantic `logo-container` class.
- Add `.logo-container` rule in main.css to center the logo via CSS.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e46c91af8832e9046ee195f1bddd3